### PR TITLE
Expand capture API with capture_channels and capture_outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4.08.x
+          - 4.11.x
           - 4.14.x
           - 5.4.x
         exclude:
           - os: windows-latest
-            ocaml-compiler: 4.08.x
+            ocaml-compiler: 4.11.x
 
     runs-on: ${{ matrix.os }}
 
@@ -37,7 +37,7 @@ jobs:
           node-version: latest
 
       - name: Set-up Binaryen
-        if: ${{ matrix.ocaml-compiler != '4.08.x' }}
+        if: ${{ matrix.ocaml-compiler != '4.11.x' }}
         uses: Aandreba/setup-binaryen@v1.0.0
         with:
           token: ${{ github.token }}
@@ -51,14 +51,14 @@ jobs:
       - run: opam install . --with-test
 
       - run: opam install wasm_of_ocaml-compiler
-        if: ${{ matrix.ocaml-compiler != '4.08.x' }}
+        if: ${{ matrix.ocaml-compiler != '4.11.x' }}
 
       - run: opam exec -- dune build
 
       - run: opam exec -- dune runtest
 
       - run: opam exec -- dune build @runtest-wasm
-        if: ${{ matrix.ocaml-compiler != '4.08.x' }}
+        if: ${{ matrix.ocaml-compiler != '4.11.x' }}
         env:
           WASM_OF_OCAML: true
 

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.28.1
+version=0.29.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+- Add `capture_channels` and `capture_channels_interleaved` for capturing
+  a list of channels (separately or merged into one string)
+- Add `capture_outputs` and `capture_outputs_interleaved` for stdout and
+  stderr (separately or merged)
+- `capture` is now an alias for `capture_outputs_interleaved`
+
 # 0.1
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ let output, result = Out_channel_redirect.capture_channel stdout ~f:(fun () ->
 (* Convenience shorthands for stdout, stderr, or both *)
 let output, result = Out_channel_redirect.capture_stdout ~f:(fun () -> print_endline "hello"; 42)
 let output, result = Out_channel_redirect.capture_stderr ~f:(fun () -> prerr_endline "hello"; 42)
-let output, result = Out_channel_redirect.capture ~f:(fun () ->
+let output, result = Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
     print_endline "hello"; prerr_endline "world"; 42)
 ```
 
@@ -56,9 +56,13 @@ end
 
 val redirect : out_channel -> into:out_channel -> f:(unit -> 'a) -> 'a
 val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
+val capture_channels : out_channel list -> f:(unit -> 'a) -> string list * 'a
+val capture_channels_interleaved :
+  out_channel list -> f:(unit -> 'a) -> string * 'a
 val capture_stdout : f:(unit -> 'a) -> string * 'a
 val capture_stderr : f:(unit -> 'a) -> string * 'a
-val capture : f:(unit -> 'a) -> string * 'a
+val capture_outputs : f:(unit -> 'a) -> string * string * 'a
+val capture_outputs_interleaved : f:(unit -> 'a) -> string * 'a
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -48,21 +48,25 @@ Out_channel_redirect.Expert.stop redir
 ## API
 
 ```ocaml
+val redirect : out_channel -> into:out_channel -> f:(unit -> 'a) -> 'a
+
+val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
+val capture_channels : out_channel list -> f:(unit -> 'a) -> string list * 'a
+val capture_channels_interleaved :
+  out_channel list -> f:(unit -> 'a) -> string * 'a
+
+val capture_stdout : f:(unit -> 'a) -> string * 'a
+val capture_stderr : f:(unit -> 'a) -> string * 'a
+val capture_outputs : f:(unit -> 'a) -> string * string * 'a
+val capture_outputs_interleaved : f:(unit -> 'a) -> string * 'a
+val capture : f:(unit -> 'a) -> string * 'a
+(* alias for capture_outputs_interleaved *)
+
 module Expert : sig
   type redirection
   val redirect : into:out_channel -> out_channel -> redirection
   val stop : redirection -> unit
 end
-
-val redirect : out_channel -> into:out_channel -> f:(unit -> 'a) -> 'a
-val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
-val capture_channels : out_channel list -> f:(unit -> 'a) -> string list * 'a
-val capture_channels_interleaved :
-  out_channel list -> f:(unit -> 'a) -> string * 'a
-val capture_stdout : f:(unit -> 'a) -> string * 'a
-val capture_stderr : f:(unit -> 'a) -> string * 'a
-val capture_outputs : f:(unit -> 'a) -> string * string * 'a
-val capture_outputs_interleaved : f:(unit -> 'a) -> string * 'a
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ end
 
 ## Requirements
 
-- OCaml >= 4.08
+- OCaml >= 4.11
 - Dune >= 3.17
 
 ## License

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
  (description
   "An OCaml library for redirecting and capturing output written to out_channels, with support\nfor native, JavaScript (js_of_ocaml), and WebAssembly (wasm_of_ocaml) targets.")
  (depends
-  (ocaml (>= 4.08))
+  (ocaml (>= 4.11))
   (ocamlformat (and (= 0.28.1) :with-dev-setup))
   (js_of_ocaml :with-test))
  (depopts (wasm_of_ocaml-compiler :with-test)))

--- a/out-channel-redirect.opam
+++ b/out-channel-redirect.opam
@@ -12,7 +12,7 @@ doc: "https://ocaml.org/p/out-channel-redirect"
 bug-reports: "https://github.com/hhugo/out-channel-redirect/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.11"}
   "ocamlformat" {= "0.28.1" & with-dev-setup}
   "js_of_ocaml" {with-test}
   "odoc" {with-doc}

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -19,7 +19,7 @@ module Expert = struct
 end
 
 let with_channel_proxy f =
-  let fname, oc = Filename.open_temp_file "" "" in
+  let fname, oc = Filename.open_temp_file "out_channel_redirect-" "" in
   Fun.protect
     ~finally:(fun () ->
       close_out_noerr oc;

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -45,17 +45,15 @@ let capture_channel chan ~f =
 let capture_stdout ~f = capture_channel stdout ~f
 let capture_stderr ~f = capture_channel stderr ~f
 
-let capture ~f =
+let capture_all chans ~f =
   with_channel_proxy (fun oc ->
-      flush stderr;
-      flush stdout;
-      let stdout_t = Expert.redirect stdout ~into:oc in
-      let stderr_t = Expert.redirect stderr ~into:oc in
+      List.iter flush chans;
+      let ts = List.map (fun c -> Expert.redirect c ~into:oc) chans in
       Fun.protect f ~finally:(fun () ->
-          flush stderr;
-          flush stdout;
-          Expert.stop stderr_t;
-          Expert.stop stdout_t))
+          List.iter flush chans;
+          List.iter Expert.stop (List.rev ts)))
+
+let capture ~f = capture_all [ stdout; stderr ] ~f
 
 let capture_outputs ~f =
   let out, (err, r) =

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -56,3 +56,19 @@ let capture ~f =
           flush stdout;
           Expert.stop stderr_t;
           Expert.stop stdout_t))
+
+let capture_outputs ~f =
+  let out, (err, r) =
+    with_channel_proxy (fun out_oc ->
+        with_channel_proxy (fun err_oc ->
+            flush stdout;
+            flush stderr;
+            let stdout_t = Expert.redirect stdout ~into:out_oc in
+            let stderr_t = Expert.redirect stderr ~into:err_oc in
+            Fun.protect f ~finally:(fun () ->
+                flush stdout;
+                flush stderr;
+                Expert.stop stderr_t;
+                Expert.stop stdout_t)))
+  in
+  (out, err, r)

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -42,10 +42,7 @@ let redirect chan ~into ~f =
 let capture_channel chan ~f =
   with_channel_proxy (fun into -> redirect chan ~into ~f)
 
-let capture_stdout ~f = capture_channel stdout ~f
-let capture_stderr ~f = capture_channel stderr ~f
-
-let capture_all chans ~f =
+let capture_channels_interleaved chans ~f =
   with_channel_proxy (fun oc ->
       List.iter flush chans;
       let ts = List.map (fun c -> Expert.redirect c ~into:oc) chans in
@@ -53,20 +50,31 @@ let capture_all chans ~f =
           List.iter flush chans;
           List.iter Expert.stop (List.rev ts)))
 
-let capture ~f = capture_all [ stdout; stderr ] ~f
+let capture_channels chans ~f =
+  let rec loop = function
+    | [] -> ([], f ())
+    | c :: rest ->
+        let s, (ss, r) =
+          with_channel_proxy (fun oc ->
+              flush c;
+              let t = Expert.redirect c ~into:oc in
+              Fun.protect
+                (fun () -> loop rest)
+                ~finally:(fun () ->
+                  flush c;
+                  Expert.stop t))
+        in
+        (s :: ss, r)
+  in
+  loop chans
+
+let capture_stdout ~f = capture_channel stdout ~f
+let capture_stderr ~f = capture_channel stderr ~f
 
 let capture_outputs ~f =
-  let out, (err, r) =
-    with_channel_proxy (fun out_oc ->
-        with_channel_proxy (fun err_oc ->
-            flush stdout;
-            flush stderr;
-            let stdout_t = Expert.redirect stdout ~into:out_oc in
-            let stderr_t = Expert.redirect stderr ~into:err_oc in
-            Fun.protect f ~finally:(fun () ->
-                flush stdout;
-                flush stderr;
-                Expert.stop stderr_t;
-                Expert.stop stdout_t)))
-  in
-  (out, err, r)
+  match capture_channels [ stdout; stderr ] ~f with
+  | [ out; err ], r -> (out, err, r)
+  | _ -> assert false
+
+let capture_outputs_interleaved ~f =
+  capture_channels_interleaved [ stdout; stderr ] ~f

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -78,3 +78,5 @@ let capture_outputs ~f =
 
 let capture_outputs_interleaved ~f =
   capture_channels_interleaved [ stdout; stderr ] ~f
+
+let capture ~f = capture_outputs_interleaved ~f

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -35,9 +35,9 @@ let with_channel_proxy f =
 let redirect chan ~into ~f =
   flush chan;
   let t = Expert.redirect chan ~into in
-  Fun.protect f ~finally:(fun () ->
-      flush chan;
-      Expert.stop t)
+  Fun.protect
+    (fun () -> Fun.protect f ~finally:(fun () -> flush chan))
+    ~finally:(fun () -> Expert.stop t)
 
 let capture_channel chan ~f =
   with_channel_proxy (fun into -> redirect chan ~into ~f)
@@ -46,9 +46,9 @@ let capture_channels_interleaved chans ~f =
   with_channel_proxy (fun oc ->
       List.iter flush chans;
       let ts = List.map (fun c -> Expert.redirect c ~into:oc) chans in
-      Fun.protect f ~finally:(fun () ->
-          List.iter flush chans;
-          List.iter Expert.stop (List.rev ts)))
+      Fun.protect
+        (fun () -> Fun.protect f ~finally:(fun () -> List.iter flush chans))
+        ~finally:(fun () -> List.iter Expert.stop (List.rev ts)))
 
 let capture_channels chans ~f =
   let rec loop = function
@@ -59,10 +59,9 @@ let capture_channels chans ~f =
               flush c;
               let t = Expert.redirect c ~into:oc in
               Fun.protect
-                (fun () -> loop rest)
-                ~finally:(fun () ->
-                  flush c;
-                  Expert.stop t))
+                (fun () ->
+                  Fun.protect (fun () -> loop rest) ~finally:(fun () -> flush c))
+                ~finally:(fun () -> Expert.stop t))
         in
         (s :: ss, r)
   in

--- a/src/out_channel_redirect.ml
+++ b/src/out_channel_redirect.ml
@@ -79,4 +79,4 @@ let capture_outputs ~f =
 let capture_outputs_interleaved ~f =
   capture_channels_interleaved [ stdout; stderr ] ~f
 
-let capture ~f = capture_outputs_interleaved ~f
+let capture = capture_outputs_interleaved

--- a/src/out_channel_redirect.mli
+++ b/src/out_channel_redirect.mli
@@ -10,3 +10,4 @@ val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
 val capture_stdout : f:(unit -> 'a) -> string * 'a
 val capture_stderr : f:(unit -> 'a) -> string * 'a
 val capture : f:(unit -> 'a) -> string * 'a
+val capture_outputs : f:(unit -> 'a) -> string * string * 'a

--- a/src/out_channel_redirect.mli
+++ b/src/out_channel_redirect.mli
@@ -10,4 +10,5 @@ val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
 val capture_stdout : f:(unit -> 'a) -> string * 'a
 val capture_stderr : f:(unit -> 'a) -> string * 'a
 val capture : f:(unit -> 'a) -> string * 'a
+val capture_all : out_channel list -> f:(unit -> 'a) -> string * 'a
 val capture_outputs : f:(unit -> 'a) -> string * string * 'a

--- a/src/out_channel_redirect.mli
+++ b/src/out_channel_redirect.mli
@@ -16,3 +16,4 @@ val capture_stdout : f:(unit -> 'a) -> string * 'a
 val capture_stderr : f:(unit -> 'a) -> string * 'a
 val capture_outputs : f:(unit -> 'a) -> string * string * 'a
 val capture_outputs_interleaved : f:(unit -> 'a) -> string * 'a
+val capture : f:(unit -> 'a) -> string * 'a

--- a/src/out_channel_redirect.mli
+++ b/src/out_channel_redirect.mli
@@ -7,8 +7,12 @@ end
 
 val redirect : out_channel -> into:out_channel -> f:(unit -> 'a) -> 'a
 val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
+val capture_channels : out_channel list -> f:(unit -> 'a) -> string list * 'a
+
+val capture_channels_interleaved :
+  out_channel list -> f:(unit -> 'a) -> string * 'a
+
 val capture_stdout : f:(unit -> 'a) -> string * 'a
 val capture_stderr : f:(unit -> 'a) -> string * 'a
-val capture : f:(unit -> 'a) -> string * 'a
-val capture_all : out_channel list -> f:(unit -> 'a) -> string * 'a
 val capture_outputs : f:(unit -> 'a) -> string * string * 'a
+val capture_outputs_interleaved : f:(unit -> 'a) -> string * 'a

--- a/src/out_channel_redirect.mli
+++ b/src/out_channel_redirect.mli
@@ -1,19 +1,67 @@
-module Expert : sig
-  type redirection
+(** Redirect and capture output written to {!Stdlib.out_channel}s.
 
-  val redirect : into:out_channel -> out_channel -> redirection
-  val stop : redirection -> unit
-end
+    Redirections operate on the underlying file descriptor, so output written by
+    C stubs or foreign code is captured as well as output written through
+    OCaml's [Stdlib] channels. *)
+
+(** {1 Redirecting} *)
 
 val redirect : out_channel -> into:out_channel -> f:(unit -> 'a) -> 'a
+(** [redirect c ~into ~f] runs [f ()] with everything written to [c] redirected
+    into [into]. [c] is flushed before and after [f], and the redirection is
+    removed even if [f] raises. *)
+
+(** {1 Capturing} *)
+
 val capture_channel : out_channel -> f:(unit -> 'a) -> string * 'a
+(** [capture_channel c ~f] runs [f ()] and returns [(s, r)] where [s] is
+    everything written to [c] during the call and [r] is [f]'s result. *)
+
 val capture_channels : out_channel list -> f:(unit -> 'a) -> string list * 'a
+(** [capture_channels cs ~f] runs [f ()] and returns one captured string per
+    channel in [cs], in the same order, along with [f]'s result. *)
 
 val capture_channels_interleaved :
   out_channel list -> f:(unit -> 'a) -> string * 'a
+(** [capture_channels_interleaved cs ~f] runs [f ()] and returns a single string
+    containing everything written to any channel in [cs], in write order, along
+    with [f]'s result. *)
+
+(** {1 Convenience for stdout and stderr} *)
 
 val capture_stdout : f:(unit -> 'a) -> string * 'a
+(** [capture_stdout] is [capture_channel stdout]. *)
+
 val capture_stderr : f:(unit -> 'a) -> string * 'a
+(** [capture_stderr] is [capture_channel stderr]. *)
+
 val capture_outputs : f:(unit -> 'a) -> string * string * 'a
+(** [capture_outputs ~f] is [capture_channels [stdout; stderr] ~f], with the two
+    strings returned as a flat triple [(stdout, stderr, r)]. *)
+
 val capture_outputs_interleaved : f:(unit -> 'a) -> string * 'a
+(** [capture_outputs_interleaved] is
+    [capture_channels_interleaved [stdout; stderr]]. *)
+
 val capture : f:(unit -> 'a) -> string * 'a
+(** Alias for {!capture_outputs_interleaved}, kept for backwards compatibility.
+*)
+
+(** {1 Expert interface} *)
+
+module Expert : sig
+  (** Low-level interface for installing and removing redirections manually.
+      Prefer the high-level functions above — they take care of flushing and
+      cleanup for you. *)
+
+  type redirection
+
+  val redirect : into:out_channel -> out_channel -> redirection
+  (** [redirect ~into c] starts redirecting everything written to [c] into
+      [into]. The caller is responsible for flushing [c] before calling and for
+      invoking {!stop} to undo the redirection. *)
+
+  val stop : redirection -> unit
+  (** [stop r] undoes the redirection installed by {!redirect}. Calling [stop]
+      more than once on the same redirection is a no-op. *)
+end

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -206,6 +206,28 @@ let () =
   assert (xs = []);
   assert (n = 42)
 
+(* capture_channels with a channel duplicated in the list: the innermost
+   redirection wins, earlier entries capture nothing *)
+let () =
+  let xs, () =
+    Out_channel_redirect.capture_channels [ stdout; stdout ] ~f:(fun () ->
+        Printf.printf "hello%!")
+  in
+  match xs with
+  | [ a; b ] ->
+      expect ~here:__LOC__ ~expected:"" a;
+      expect ~here:__LOC__ ~expected:"hello" b
+  | _ -> assert false
+
+(* capture_channels_interleaved with a duplicated channel: output appears
+   once *)
+let () =
+  let s, () =
+    Out_channel_redirect.capture_channels_interleaved [ stdout; stdout ]
+      ~f:(fun () -> Printf.printf "hello%!")
+  in
+  expect ~here:__LOC__ ~expected:"hello" s
+
 (* capture_outputs returns stdout and stderr separately *)
 let () =
   let out, err, () =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -207,8 +207,11 @@ let () =
   assert (n = 42)
 
 (* capture_channels_interleaved flushes channels in list order at the
-   end of [f]. With buffered channels, the list order therefore determines
-   which buffer reaches the capture file first. *)
+   end of [f]. On Native/Bytecode each channel keeps its own buffer, so
+   the list order determines which buffer reaches the capture file first.
+   On JS/Wasm the redirect swaps the entire channel object: writes to any
+   listed channel go into the proxy's buffer in call order, regardless of
+   list order. *)
 let () =
   let tmp1, c1 = Filename.open_temp_file "test-" "" in
   let tmp2, c2 = Filename.open_temp_file "test-" "" in
@@ -223,7 +226,9 @@ let () =
         output_string c1 "a";
         output_string c2 "b")
   in
-  expect ~here:__LOC__ ~expected:"ba" s_b_then_a;
+  (match Sys.backend_type with
+  | Native | Bytecode -> expect ~here:__LOC__ ~expected:"ba" s_b_then_a
+  | Other _ -> expect ~here:__LOC__ ~expected:"ab" s_b_then_a);
   close_out_noerr c1;
   close_out_noerr c2;
   Sys.remove tmp1;

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -227,7 +227,8 @@ let () =
         output_string c2 "b")
   in
   (match Sys.backend_type with
-  | Native | Bytecode -> expect ~here:__LOC__ ~expected:"ba" s_b_then_a
+  | Native | Bytecode | Other "wasm_of_ocaml" ->
+      expect ~here:__LOC__ ~expected:"ba" s_b_then_a
   | Other _ -> expect ~here:__LOC__ ~expected:"ab" s_b_then_a);
   close_out_noerr c1;
   close_out_noerr c2;

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -187,6 +187,32 @@ let () =
   in
   expect ~here:__LOC__ ~expected:big s
 
+(* capture_outputs returns stdout and stderr separately *)
+let () =
+  let out, err, () =
+    Out_channel_redirect.capture_outputs ~f:(fun () ->
+        Printf.printf "to-stdout%!";
+        Printf.eprintf "to-stderr%!")
+  in
+  expect ~here:__LOC__ ~expected:"to-stdout" out;
+  expect ~here:__LOC__ ~expected:"to-stderr" err
+
+(* Exception safety: capture_outputs restores both channels on exception *)
+let () =
+  (try
+     ignore
+       (Out_channel_redirect.capture_outputs ~f:(fun () ->
+            Printf.printf "before%!";
+            Printf.eprintf "before%!";
+            failwith "test exception"))
+   with Failure _ -> ());
+  let s, () =
+    Out_channel_redirect.capture ~f:(fun () ->
+        Printf.printf "stdout%!";
+        Printf.eprintf "stderr%!")
+  in
+  expect ~here:__LOC__ ~expected:"stdoutstderr" s
+
 (* Exception safety: capture_channel' restores on exception *)
 let () =
   let _, () =

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -7,7 +7,7 @@ let expect ~here ~expected s =
 
 let () =
   let s, () =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         Printf.printf "printf%!";
         Printf.eprintf "eprintf%!")
   in
@@ -15,7 +15,7 @@ let () =
 
 let () =
   let s, inner =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         let (inner : string), () =
           Out_channel_redirect.capture_stdout ~f:(fun () ->
               Printf.printf "printf%!";
@@ -28,7 +28,7 @@ let () =
 
 let () =
   let s, inner =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         let (inner : string), () =
           Out_channel_redirect.capture_stderr ~f:(fun () ->
               Printf.printf "printf%!";
@@ -96,14 +96,14 @@ let () =
 
 let () =
   let s, () =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         Out_channel_redirect_test_helper.out_channel_redirect_print_stdout ())
   in
   expect ~here:__LOC__ ~expected:"stdout from external" s
 
 let () =
   let s, () =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         Out_channel_redirect_test_helper.out_channel_redirect_print_stderr ())
   in
   expect ~here:__LOC__ ~expected:"stderr from external" s
@@ -134,17 +134,17 @@ let () =
   in
   expect ~here:__LOC__ ~expected:"after" s
 
-(* Exception safety: capture restores both channels on exception *)
+(* Exception safety: capture_outputs_interleaved restores both channels on exception *)
 let () =
   (try
      ignore
-       (Out_channel_redirect.capture ~f:(fun () ->
+       (Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
             Printf.printf "before%!";
             Printf.eprintf "before%!";
             failwith "test exception"))
    with Failure _ -> ());
   let s, () =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         Printf.printf "stdout%!";
         Printf.eprintf "stderr%!")
   in
@@ -187,6 +187,25 @@ let () =
   in
   expect ~here:__LOC__ ~expected:big s
 
+(* capture_channels returns one string per channel *)
+let () =
+  let xs, () =
+    Out_channel_redirect.capture_channels [ stdout; stderr ] ~f:(fun () ->
+        Printf.printf "out%!";
+        Printf.eprintf "err%!")
+  in
+  match xs with
+  | [ out; err ] ->
+      expect ~here:__LOC__ ~expected:"out" out;
+      expect ~here:__LOC__ ~expected:"err" err
+  | _ -> assert false
+
+(* capture_channels with an empty list just runs f *)
+let () =
+  let xs, n = Out_channel_redirect.capture_channels [] ~f:(fun () -> 42) in
+  assert (xs = []);
+  assert (n = 42)
+
 (* capture_outputs returns stdout and stderr separately *)
 let () =
   let out, err, () =
@@ -207,7 +226,7 @@ let () =
             failwith "test exception"))
    with Failure _ -> ());
   let s, () =
-    Out_channel_redirect.capture ~f:(fun () ->
+    Out_channel_redirect.capture_outputs_interleaved ~f:(fun () ->
         Printf.printf "stdout%!";
         Printf.eprintf "stderr%!")
   in

--- a/test/basic.ml
+++ b/test/basic.ml
@@ -206,6 +206,41 @@ let () =
   assert (xs = []);
   assert (n = 42)
 
+(* capture_channels_interleaved flushes channels in list order at the
+   end of [f]. With buffered channels, the list order therefore determines
+   which buffer reaches the capture file first. *)
+let () =
+  let tmp1, c1 = Filename.open_temp_file "test-" "" in
+  let tmp2, c2 = Filename.open_temp_file "test-" "" in
+  let s_a_then_b, () =
+    Out_channel_redirect.capture_channels_interleaved [ c1; c2 ] ~f:(fun () ->
+        output_string c1 "a";
+        output_string c2 "b")
+  in
+  expect ~here:__LOC__ ~expected:"ab" s_a_then_b;
+  let s_b_then_a, () =
+    Out_channel_redirect.capture_channels_interleaved [ c2; c1 ] ~f:(fun () ->
+        output_string c1 "a";
+        output_string c2 "b")
+  in
+  expect ~here:__LOC__ ~expected:"ba" s_b_then_a;
+  close_out_noerr c1;
+  close_out_noerr c2;
+  Sys.remove tmp1;
+  Sys.remove tmp2
+
+(* capture_channels_interleaved merges output from several channels in
+   write order *)
+let () =
+  let s, () =
+    Out_channel_redirect.capture_channels_interleaved [ stdout; stderr ]
+      ~f:(fun () ->
+        Printf.printf "1%!";
+        Printf.eprintf "2%!";
+        Printf.printf "3%!")
+  in
+  expect ~here:__LOC__ ~expected:"123" s
+
 (* capture_channels with a channel duplicated in the list: the innermost
    redirection wins, earlier entries capture nothing *)
 let () =


### PR DESCRIPTION
## Summary
- Add `capture_channels` and `capture_channels_interleaved` for capturing a list of `out_channel`s, returning either a list of strings (one per channel) or a single interleaved string.
- Add `capture_outputs` and `capture_outputs_interleaved` as stdout+stderr specializations.
- Keep `capture` as an alias for `capture_outputs_interleaved` for backwards compatibility (semantically unchanged from 0.1).
- Reorder `.mli` with section headings and add docstrings to every public value.
- Use a prefixed temp file name (`out_channel_redirect-…`) so leaked files are identifiable on crash.
- Nest `Fun.protect` calls so `Expert.stop` always runs even if `flush` raises during cleanup.
- Bump ocamlformat to 0.29.0.

## Test plan
- [x] `dune build src/ test/basic.exe`
- [x] `dune exec test/basic.exe`
- New tests cover: multi-channel interleaving, empty channel list, duplicate channels (both interleaved and per-channel variants), flush order driven by list order, exception safety for the new functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)